### PR TITLE
Avoid fatality when we cannot ping

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,10 +74,12 @@ func pinga() {
 	form.Add("eventid", "inga")
 	t := time.Now()
 	form.Add("datetime", t.Format("20060102150405"))
+
 	resp, err := http.PostForm(target, form)
-	defer resp.Body.Close()
 	if err != nil {
-		log.Fatalln(err)
+		log.Println(err)
+	} else {
+		defer resp.Body.Close()
 	}
 }
 


### PR DESCRIPTION
While smoke-testing a deploy of the TLS inga, I accidentally discovered that there are two different fatal errors if pinging fails:
- the defer fails (because `resp` is nil);
- the `log.Fatal`, triggered by `err != nil` exits the program.

